### PR TITLE
feat: add Task schema and in-memory task endpoints

### DIFF
--- a/app/api/task_router.py
+++ b/app/api/task_router.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from app.schemas.task import Task
+
+router = APIRouter()
+
+# In-memory task list
+tasks = []
+
+@router.get("/tasks", response_model=list[Task])
+def get_tasks():
+    return tasks
+
+@router.post("/tasks", response_model=Task)
+def create_task(task: Task):
+    tasks.append(task)
+    return task

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
-# app/main.py
-
 from fastapi import FastAPI
+from app.api.task_router import router as task_router
 
 app = FastAPI()
+
+app.include_router(task_router)
 
 @app.get("/")
 def read_root():

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class Task(BaseModel):
+    id: int
+    title: str
+    is_completed: bool = False


### PR DESCRIPTION
###  What’s Added

- `Task` Pydantic model
- In-memory list for storing tasks
- Endpoints:
  - `GET /tasks`
  - `POST /tasks`

###  How to Test
```bash
docker-compose up
