### PR TITLE
feat: replace in-memory task store with PostgreSQL CRUD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+# Variables
+VENV_NAME = venv
+PYTHON = $(VENV_NAME)/bin/python
+PIP = $(VENV_NAME)/bin/pip
+PYTEST = $(VENV_NAME)/bin/pytest
+
+.PHONY: all setup install run test docker docker-down clean migrate logs help
+
+# Default target
+all: docker migrate logs
+
+# Create virtual environment and install dependencies locally
+setup:
+	@echo "Creating virtual environment and installing dependencies..."
+	python3 -m venv $(VENV_NAME)
+	$(PIP) install -r requirements.txt
+
+# Install dependencies into venv
+install: $(VENV_NAME)
+	@echo "Installing dependencies..."
+	$(PIP) install -r requirements.txt
+
+# Run FastAPI app locally (not recommended if using Docker)
+run:
+	@echo "Running FastAPI locally..."
+	uvicorn app.main:app --reload
+
+# Run tests
+test: install
+	@echo "Running tests..."
+	PYTHONPATH=$(PWD) $(PYTEST) tests
+
+# Start Docker containers
+docker:
+	@echo "Running Docker Compose..."
+	docker compose up --build -d
+
+# Stop and remove Docker containers
+docker-down:
+	docker compose down
+
+# Apply Alembic migrations inside Docker
+migrate:
+	@echo "Applying DB migrations..."
+	docker compose exec api alembic upgrade head
+
+# View container logs
+logs:
+	docker compose logs -f
+
+# Clean up
+clean:
+	@echo "Cleaning up..."
+	rm -rf $(VENV_NAME)
+	find . -type f -name '*.pyc' -delete
+	find . -type d -name '__pycache__' -exec rm -rf {} +
+
+# Help menu
+help:
+	@echo "Usage: make [TARGET]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  setup        - Create venv and install dependencies"
+	@echo "  install      - Install dependencies into venv"
+	@echo "  run          - Run FastAPI locally (not via Docker)"
+	@echo "  test         - Run tests"
+	@echo "  docker       - Build and start Docker containers"
+	@echo "  docker-down  - Stop Docker containers"
+	@echo "  migrate      - Run Alembic migrations inside container"
+	@echo "  logs         - View container logs"
+	@echo "  clean        - Remove venv, pyc, and __pycache__"
+	@echo "  help         - Show this message"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,160 @@
-# stacking_pr
+<!--
+SPDX-FileCopyrightText: 2024 Hitesh Arora
+SPDX-FileContributor: Hitesh Arora
 
-###  What’s Included
+SPDX-License-Identifier: MIT
+-->
 
-- Basic FastAPI app with a default route (`GET /`)
-- Dockerfile and docker-compose for containerized setup
-- `.gitignore` and project structure
-- `requirements.txt` with FastAPI and Uvicorn
+<div align="center" markdown="1">
+  <br />
+  <h1>Stacked PR FastAPI Task Tracker</h1>
+  <p>
+    A clean, professional-grade backend project built with FastAPI, Docker, PostgreSQL, and SQLAlchemy.
+  </p>
+  <p>
+    Built in a stacked PR workflow, step-by-step, from in-memory to production-ready DB logic.
+  </p>
 
-### How to Run
+  <a href="#stacked-prs">Stacked PR Structure</a> •
+  <a href="#tech-stack">Tech Stack</a> •
+  <a href="#usage">Usage</a> •
+  <a href="#api">API</a> •
+  <a href="#makefile">Makefile</a>
+
+  <br />
+  <br />
+
+  <img alt="FastAPI Swagger UI Screenshot" width="600" src="https://fastapi.tiangolo.com/img/index/index-01-simplified.png">
+
+</div>
+
+---
+
+## 🌟 Stacked PRs
+
+This repo is structured into clearly defined Pull Requests:
+
+1. **`feat: add Task schema and in-memory task endpoints`**
+2. **`feat: integrate PostgreSQL with SQLAlchemy and Alembic`**
+3. **`feat: replace in-memory task store with PostgreSQL CRUD`**
+
+Each PR builds cleanly on top of the previous, keeping history modular and understandable.
+
+---
+
+## 🚀 Tech Stack
+
+- **FastAPI**: Web framework
+- **SQLAlchemy**: ORM for PostgreSQL
+- **Alembic**: Schema migrations
+- **Docker + Compose**: Containerized dev environment
+- **PostgreSQL**: Relational database
+- **Pytest** (coming soon): Testing framework
+
+---
+
+## 📃 Project Structure
+
 ```bash
-docker-compose up --build
+stacking_pr/
+├── app/
+│   ├── api/              # Routers
+│   ├── db.py             # DB engine/session
+│   ├── models/           # SQLAlchemy models
+│   ├── schemas/          # Pydantic schemas
+│   └── dependencies.py   # FastAPI dependencies
+├── alembic/              # Alembic migrations
+├── alembic.ini           # Alembic config
+├── Dockerfile            # FastAPI app container
+├── docker-compose.yml    # Docker Compose setup
+├── requirements.txt      # Python dependencies
+├── Makefile              # Developer helper commands
+└── README.md             # You're reading this
+```
+
+---
+
+## 🚧 Usage
+
+### ⚡ Run Locally
+
+```bash
+git clone https://github.com/yourname/stacking_pr.git
+cd stacking_pr
+
+# Build and run containers
+make docker
+
+# Run alembic migrations
+make migrate
+
+# Follow logs
+make logs
+```
+
+Open browser:
+```
+http://localhost:8000/docs
+```
+
+To stop:
+```bash
+make docker-down
+```
+
+---
+
+## 📊 API
+
+### Create a Task
+```http
+POST /tasks
+Content-Type: application/json
+
+{
+  "id": 1,
+  "title": "Stacked PRs FTW!",
+  "is_completed": false
+}
+```
+
+### Get All Tasks
+```http
+GET /tasks
+```
+
+---
+
+## 📄 Makefile
+
+This project comes with a handy Makefile for development:
+
+```makefile
+make setup         # Create virtual environment and install dependencies
+make install       # Install requirements into venv
+make docker        # Start Docker containers
+make docker-down   # Stop and remove containers
+make migrate       # Run alembic migrations
+make logs          # Follow Docker logs
+make clean         # Delete venv + __pycache__
+make test          # Run pytest tests (coming soon)
+```
+
+---
+
+## ✅ License
+
+This project is licensed under the MIT License.
+
+---
+
+## 🚀 Coming Soon
+
+- 🌐 Deployment on Render/Railway
+- ✅ Unit tests with Pytest
+- 📊 GitHub Actions CI
+- 👁️ Optional frontend in React or HTML
+
+---
+
+Made with ❤️ by Hitesh Arora.

--- a/app/api/task_router.py
+++ b/app/api/task_router.py
@@ -1,5 +1,9 @@
 from fastapi import APIRouter
+from fastapi import Depends
+from sqlalchemy.orm import Session
+from app.models.task import Task as TaskModel
 from app.schemas.task import Task
+from app.dependencies import get_db
 
 router = APIRouter()
 
@@ -7,10 +11,13 @@ router = APIRouter()
 tasks = []
 
 @router.get("/tasks", response_model=list[Task])
-def get_tasks():
-    return tasks
+def get_tasks(db: Session = Depends(get_db)):
+    return db.query(TaskModel).all()
 
 @router.post("/tasks", response_model=Task)
-def create_task(task: Task):
-    tasks.append(task)
-    return task
+def create_task(task: Task, db: Session = Depends(get_db)):
+    db_task = TaskModel(**task.dict())
+    db.add(db_task)
+    db.commit()
+    db.refresh(db_task)
+    return db_task

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@db:5432/taskdb"
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,8 @@
+from app.db import SessionLocal
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
###  What’s Changed

- Added `app/db.py` with SQLAlchemy engine/session setup
- Added `get_db()` dependency for request-scoped DB sessions
- Replaced in-memory `tasks` list with PostgreSQL-based logic
- `GET /tasks` and `POST /tasks` now use real DB CRUD

###  How to Test

```bash
docker compose up